### PR TITLE
Flip lattice drawings by graphviz

### DIFF
--- a/6 Abstract Interpretation.ipynb
+++ b/6 Abstract Interpretation.ipynb
@@ -630,6 +630,8 @@
     "            for d in ds:\n",
     "                dot.edge(str(self.element_by_index(s)), str(self.element_by_index(d)))\n",
     "\n",
+    "        dot.graph_attr.update(rankdir='BT')\n",
+    "\n",
     "        return dot\n",
     "\n",
     "    def __repr__(self):\n",


### PR DESCRIPTION
This fixes that the lattices are drawn the wrong way around by graphviz.